### PR TITLE
Cleanups and removal of deprecated exports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 *.py[cod]
 
-/.project
-/.pydevproject
-/.settings/
+.project
+.pydevproject
+.settings/
 
 # Distribution / packaging
 build/
 dist/
 
-/src/nti.property.egg-info
-/.tox/
+*.egg-info
+.tox/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 2.7
   - 3.6
   - pypy-5.4.1
-dist: trusty
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress --all
 after_success:
@@ -16,7 +15,6 @@ install:
   - pip install -U pip
   - pip install -U setuptools
   - pip install -U coveralls coverage
-  - pip install -U zope.testrunner
   - pip install -U -e ".[test]"
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,4 +7,5 @@
 ==================
 
 - First PyPI release.
-- Add support for Python 3.
+- Add support for Python 3.6.
+- Remove backward compatibility exports.

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,10 @@ setup(
     tests_require=TESTS_REQUIRE,
     install_requires=[
         'setuptools',
-        'six',
         'zope.annotation',
-        'zope.cachedescriptors',
+        'zope.cachedescriptors >= 4.2',
         'zope.contenttype',
-        'zope.file',
+        'zope.file >= 1.0',
         'zope.schema',
     ],
     extras_require={

--- a/src/nti/property/__init__.py
+++ b/src/nti/property/__init__.py
@@ -1,26 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-.. $Id$
+
 """
 
 from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
-
-logger = __import__('logging').getLogger(__name__)
-
-from nti.property.property import readproperty
-
-from nti.property.property import alias
-from nti.property.property import read_alias
-
-from nti.property.property import dict_alias
-from nti.property.property import dict_read_alias
-
-from nti.property.property import annotation_alias
-
-from nti.property.property import Lazy
-from nti.property.property import LazyOnClass
-from nti.property.property import CachedProperty
-
-from nti.property.urlproperty import UrlProperty

--- a/src/nti/property/dataurl.py
+++ b/src/nti/property/dataurl.py
@@ -13,7 +13,6 @@ octets outside that range. If ``<MIME-type>`` is omitted, it defaults
 to ``text/plain;charset=US-ASCII``. (As a shorthand, the type can be
 omitted but the charset parameter supplied.)
 
-.. $Id$
 """
 
 from __future__ import print_function, absolute_import, division
@@ -21,7 +20,6 @@ __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
 
-import six
 
 from zope.cachedescriptors.property import CachedProperty
 
@@ -115,7 +113,7 @@ def encode(raw_bytes,
             is directly output as quoted ASCII bytes.
     :returns: Data URL byte string
     """
-    if not isinstance(raw_bytes, six.binary_type):
+    if not isinstance(raw_bytes, bytes): # pragma: no cover
         raise TypeError("only raw bytes can be encoded")
 
     if encoder == "base64":

--- a/src/nti/property/property.py
+++ b/src/nti/property/property.py
@@ -72,16 +72,6 @@ def dict_read_alias(key_name, doc=None):
     return property(lambda self: self.__dict__[key_name],
                     doc=doc)
 
-from zope.cachedescriptors.property import readproperty
-readproperty = readproperty  # BWC export
-
-from zope.cachedescriptors.property import Lazy
-Lazy = Lazy  # BWC export
-
-from zope.cachedescriptors.property import CachedProperty
-CachedProperty = CachedProperty  # BWC export
-
-
 class LazyOnClass(object):
     """
     Like :class:`zope.cachedescriptors.property.Lazy`, but
@@ -136,8 +126,8 @@ def annotation_alias(annotation_name, annotation_property=None, default=None,
         factory = lambda self: IAnnotations(getattr(self, annotation_property))
 
     fget = lambda self: factory(self).get(annotation_name, default)
-    fset = lambda self, nv: operator.setitem(factory(self), 
-                                             annotation_name, 
+    fset = lambda self, nv: operator.setitem(factory(self),
+                                             annotation_name,
                                              nv)
     fdel = None
     if delete:

--- a/src/nti/property/schema.py
+++ b/src/nti/property/schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-.. $Id$
+
 """
 
 from __future__ import print_function, absolute_import, division
@@ -36,6 +36,6 @@ class DataURI(schema.URI):
     def fromUnicode(self, value):
         if isinstance(value, dataurl.DataURL):
             return value
-        else:
-            super(DataURI, self).fromUnicode(value)
-            return dataurl.DataURL(value)
+
+        super(DataURI, self).fromUnicode(value)
+        return dataurl.DataURL(value)

--- a/src/nti/property/tests/test_property.py
+++ b/src/nti/property/tests/test_property.py
@@ -20,7 +20,6 @@ from zope.annotation import interfaces as an_interfaces
 from nti.property.property import alias
 from nti.property.property import dict_alias
 from nti.property.property import LazyOnClass
-from nti.property.property import CachedProperty
 from nti.property.property import dict_read_alias
 from nti.property.property import annotation_alias
 
@@ -30,11 +29,11 @@ from nti.property.tests import PropertyLayerTest
 class TestProperty(PropertyLayerTest):
 
     def test_alias(self):
-        
+
         class X(object):
-            
+
             y = alias('x')
-            
+
             def __init__(self):
                 self.x = 1
 
@@ -72,7 +71,7 @@ class TestProperty(PropertyLayerTest):
             x.y = 2
 
     def test_cached_property(self):
-
+        from zope.cachedescriptors.property import CachedProperty
         # Usable directly
         class X(object):
 
@@ -135,18 +134,18 @@ class TestProperty(PropertyLayerTest):
 
         class Y(dict):
             pass
-        
+
         @interface.implementer(an_interfaces.IAnnotations)
         class Z(dict):
             y = Y()
             the_alias = annotation_alias('the.key',
                                          annotation_property="Y",
                                          delete=True, default=1)
-            
+
     def test_lazy_on_class(self):
 
         class X(dict):
-            
+
             @LazyOnClass
             def _foo(self):
                 return "boo"

--- a/src/nti/property/urlproperty.py
+++ b/src/nti/property/urlproperty.py
@@ -58,7 +58,7 @@ class UrlProperty(object):
     instance holding the property. This object will ensure that the file is located
     (in the :mod:`zope.location` sense) as a child of the instance, and that it has a name;
     it is the responsibility of the instance to arrange for it to be traversable
-    (through implementing __getitem__ or ITraversable or an adapter).
+    (through implementing ``__getitem__`` or ITraversable or an adapter).
 
     """
 
@@ -144,7 +144,7 @@ class UrlProperty(object):
             if self.max_file_size and len(raw_bytes) > self.max_file_size:
                 raise ConstraintNotSatisfied("The uploaded file is too large.")
             major, minor, parms = ct_parse(mime_type)
-            the_file = zfile.File(mimeType=major + '/' + minor, 
+            the_file = zfile.File(mimeType=major + '/' + minor,
                                   parameters=parms)
             fp = the_file.open('w')
             fp.write(raw_bytes)

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,5 @@ envlist = pypy, py27, py36
 deps =
 	 .[test]
 
-setenv =
-    CHAMELEON_CACHE={envbindir}
-
 commands =
          zope-testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args


### PR DESCRIPTION
This should run Travis and Coveralls. 

We don't have 100% test coverage. We need that before releasing to PyPI.

In particular, the DataURL seems to be completely untested.